### PR TITLE
Pass a partition value for queries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+max_line_length = null
+indent_style = space
+insert_final_newline = true
+
+# PHP
+[*.php]
+indent_size = 4
+
+# JSON
+[*.{json}]
+indent_size = 4
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Include jupitern/cosmosdb in your project, by adding it to your composer.json fi
 
 ## Changelog
 
-### v2.1.0
+### v2.4.0
 
 - added support for nested partition keys
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ $conn = new \Jupitern\CosmosDb\CosmosDb('hostName', 'primaryKey');
 $conn->setHttpClientOptions(['verify' => false]); # optional: set guzzle client options.
 $db = $conn->selectDB('dbName');
 $collection = $db->selectCollection('collectionName');
+
+# if a collection does not exist, it will be created when you
+# attempt to select the collection. however, if you have created
+# your database with shared throughput, then all collections require a partition key.
+# selectCollection() supports a second parameter for this purpose.
+$conn = new \Jupitern\CosmosDb\CosmosDb('hostName', 'primaryKey');
+$conn->setHttpClientOptions(['verify' => false]); # optional: set guzzle client options.
+$db = $conn->selectDB('dbName');
+$collection = $db->selectCollection('collectionName', 'myPartitionKey');
 ```
 
 ### Inserting Records

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This package adds additional functionalities to the [AzureDocumentDB-PHP](https:
 
 ## Limitations
 
-Using `order by` or `top` in cross-partition queries is currently not supported.
+Use of `limit()` or `order()` in cross-partition queries is currently not supported.
 
 ## Usage
 
@@ -106,13 +106,13 @@ $res = \Jupitern\CosmosDb\QueryBuilder::instance()
 # query against your database as it will not rely
 # on cross-partition querying
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
-->setCollection($collection)
-->setPartitionValue('Portugal')
-->select("c.id, c.name")
-->where("c.age > @age and c.country = @country")
-->params(['@age' => 30, '@country' => 'Portugal'])
-->find()
-->toArray();
+    ->setCollection($collection)
+    ->setPartitionValue('Portugal')
+    ->select("c.id, c.name")
+    ->where("c.age > @age and c.country = @country")
+    ->params(['@age' => 30, '@country' => 'Portugal'])
+    ->find()
+    ->toArray();
 
 # query the top 5 documents as an array, with the
 # document ID as the array key.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Include jupitern/cosmosdb in your project, by adding it to your composer.json fi
 
 - added support for nested partition keys
 
+- added support for creating collections with partition keys
+
 - pass a known partition value when querying as an alternative to cross-partition queries
 
 ### v2.0.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # cosmosdb
+
 PHP wrapper for Azure Cosmos DB
 
 ## Installation
 
 Include jupitern/cosmosdb in your project, by adding it to your composer.json file.
+
 ```php
 {
     "require": {
@@ -15,31 +17,34 @@ Include jupitern/cosmosdb in your project, by adding it to your composer.json fi
 ## Changelog
 
 ### v2.1.0
-- support for nested partition keys
+
+- added support for nested partition keys
+
 - pass a known partition value when querying as an alternative to cross-partition queries
 
 ### v2.0.0
+
 - support for cross partition queries
+
 - selectCollection method removed from all methods for performance improvements
 
 ### v1.4.4
+
 - replaced pear package http_request2 by guzzle
+
 - added method to provide guzzle configuration
 
 ### v1.3.0
-- added support for parameterized queries
 
+- added support for parameterized queries
 
 ## Note
 
-this package adds functionalities to the package bellow so all functionalities provided in base package are also available
-
-https://github.com/cocteau666/AzureDocumentDB-PHP
+This package adds additional functionalities to the [AzureDocumentDB-PHP](https://github.com/cocteau666/AzureDocumentDB-PHP) package. All other functionality exists in this package as well.
 
 ## Limitations
 
-in cross partition queries order by or top are not supported at this moment
-
+Using `order by` or `top` in cross-partition queries is currently not supported.
 
 ## Usage
 
@@ -47,7 +52,7 @@ in cross partition queries order by or top are not supported at this moment
 
 ```php
 $conn = new \Jupitern\CosmosDb\CosmosDb('hostName', 'primaryKey');
-$conn->setHttpClientOptions(['verify' => false]); // optional: set guzzle client options.
+$conn->setHttpClientOptions(['verify' => false]); # optional: set guzzle client options.
 $db = $conn->selectDB('dbName');
 $collection = $db->selectCollection('collectionName');
 ```
@@ -56,17 +61,17 @@ $collection = $db->selectCollection('collectionName');
 
 ```php
 
-// consider a existing collection called "Users" with a partition key "country"
+# consider a existing collection called "Users" with a partition key "country"
 
-// insert a record
+# insert a record
 $rid = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->setPartitionKey('country')
     ->save(['id' => '1', 'name' => 'John Doe', 'age' => 22, 'country' => 'Portugal']);
 
-// insert a record against a collection with a nested partition key
-// note: this follows the same string format as is used when creating
-// a collection with a partition key via the Azure Portal
+# insert a record against a collection with a nested partition key
+# note: this follows the same string format as is used when creating
+# a collection with a partition key via the Azure Portal
 $rid = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->setPartitionKey('/form/person/country')
@@ -76,7 +81,7 @@ $rid = \Jupitern\CosmosDb\QueryBuilder::instance()
 ### Updating Records
 
 ```php
-// update a record
+# update a record
 $rid = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->setPartitionKey('country')
@@ -86,20 +91,20 @@ $rid = \Jupitern\CosmosDb\QueryBuilder::instance()
 ### Querying Records
 
 ```php
-// query a document and return it as an array
+# query a document and return it as an array
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->select("c.id, c.name")
     ->where("c.age > @age and c.country = @country")
     ->params(['@age' => 30, '@country' => 'Portugal'])
-    ->find(true) // pass true if is cross partition query
+    ->find(true) # pass true if is cross partition query
     ->toArray();
 
-// query a document using a known partition value,
-// and return as an array. note: setting a known
-// partition value will result in a more efficient
-// query against your database as it will not rely
-// on cross-partition querying
+# query a document using a known partition value,
+# and return as an array. note: setting a known
+# partition value will result in a more efficient
+# query against your database as it will not rely
+# on cross-partition querying
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
 ->setCollection($collection)
 ->setPartitionValue('Portugal')
@@ -109,39 +114,39 @@ $res = \Jupitern\CosmosDb\QueryBuilder::instance()
 ->find()
 ->toArray();
 
-// query the top 5 documents as an array, with the
-// document ID as the array key.
-// note: refer to limitations section
+# query the top 5 documents as an array, with the
+# document ID as the array key.
+# note: refer to limitations section
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->select("c.id, c.username")
     ->where("c.age > @age and c.country = @country")
     ->params(['@age' => 10, '@country' => 'Portugal'])
     ->limit(5)
-    ->findAll() // cannot limit cross-partition queries
+    ->findAll() # cannot limit cross-partition queries
     ->toArray('id');
 
-// query a document using a collection alias and cross partition query
+# query a document using a collection alias and cross partition query
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->select("TestColl.id, TestColl.name")
     ->from("TestColl")
     ->where("TestColl.age > 30")
-    ->findAll(true) // pass true if is cross partition query
+    ->findAll(true) # pass true if is cross partition query
     ->toArray();
 ```
 
 ### Deleting Records
 
 ```php
-// delete one document that matches criteria (single partition)
+# delete one document that matches criteria (single partition)
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->setPartitionKey('country')
     ->where("c.age > 30 and c.country = 'Portugal'")
     ->delete();
 
-// delete all documents that match criteria (cross partition)
+# delete all documents that match criteria (cross partition)
 $res = \Jupitern\CosmosDb\QueryBuilder::instance()
     ->setCollection($collection)
     ->setPartitionKey('country')

--- a/src/CosmosDb.php
+++ b/src/CosmosDb.php
@@ -188,7 +188,7 @@ class CosmosDb
 		$headers['x-ms-max-item-count'] = -1;
 		$headers['x-ms-documentdb-isquery'] = 'True';
 
-		if ($isCrossPartition) {
+        if ($isCrossPartition) {
             $headers['x-ms-documentdb-query-enablecrosspartition'] = 'True';
         }
 

--- a/src/CosmosDb.php
+++ b/src/CosmosDb.php
@@ -180,7 +180,7 @@ class CosmosDb
      * @param boolean $isCrossPartition used for cross partition query
      * @return string JSON response
      */
-	public function query($rid_id, $rid_col, $query, $isCrossPartition = false)
+	public function query($rid_id, $rid_col, $query, $isCrossPartition = false, $partitionValue = null)
 	{
 		$headers = $this->getAuthHeaders('POST', 'docs', $rid_col);
 		$headers['Content-Length'] = strlen($query);
@@ -188,8 +188,13 @@ class CosmosDb
 		$headers['x-ms-max-item-count'] = -1;
 		$headers['x-ms-documentdb-isquery'] = 'True';
 
-		if ($isCrossPartition)
-			$headers['x-ms-documentdb-query-enablecrosspartition'] = 'True';
+		if ($isCrossPartition) {
+            $headers['x-ms-documentdb-query-enablecrosspartition'] = 'True';
+        }
+
+        if ($partitionValue) {
+            $headers['x-ms-documentdb-partitionkey'] = '["'.$partitionValue.'"]';
+        }
 
 		try {
 			$result = $this->request("/dbs/" . $rid_id . "/colls/" . $rid_col . "/docs", "POST", $headers, $query);

--- a/src/CosmosDbCollection.php
+++ b/src/CosmosDbCollection.php
@@ -3,17 +3,17 @@
 namespace Jupitern\CosmosDb;
 
 /*
- * Copyright (C) 2014 - 2017 Takeshi SAKURAI <sakurai@pnop.co.jp>
- *      http://www.pnop.co.jp/
+ * Based on the AzureDocumentDB-PHP library written by Takeshi Sakurai.
+ * With updates and added features contributed by @jupitern and @purplekrayons
  *
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -21,13 +21,8 @@ namespace Jupitern\CosmosDb;
 
 /**
  * Microsoft Azure Document DB Library for PHP
- *
- * Wrapper class of Document DB REST API
- *
  * @link http://msdn.microsoft.com/en-us/library/azure/dn781481.aspx
- * @version 2.8
- * @author Takeshi SAKURAI <sakurai@pnop.co.jp>
- * @since PHP 5.3
+ * @link https://github.com/jupitern/cosmosdb
  */
 
 class CosmosDbCollection
@@ -162,6 +157,7 @@ class CosmosDbCollection
         return $this->document_db->getPermission($this->rid_db, $uid, $pid);
       }
     */
+    
     public function listStoredProcedures()
     {
         return $this->document_db->listStoredProcedures($this->rid_db, $this->rid_col);

--- a/src/CosmosDbCollection.php
+++ b/src/CosmosDbCollection.php
@@ -59,7 +59,7 @@ class CosmosDbCollection
      * @param boolean $isCrossPartition used for cross partition query
      * @return string JSON strings
      */
-    public function query($query, $params = [], $isCrossPartition = false)
+    public function query($query, $params = [], $isCrossPartition = false, $partitionValue = null)
     {
         $paramsJson = [];
         foreach ($params as $key => $val) {
@@ -70,7 +70,7 @@ class CosmosDbCollection
 
         $query = '{"query": "' . str_replace('"', '\\"', $query) . '", "parameters": [' . implode(',', $paramsJson) . ']}';
 
-        return $this->document_db->query($this->rid_db, $this->rid_col, $query, $isCrossPartition);
+        return $this->document_db->query($this->rid_db, $this->rid_col, $query, $isCrossPartition, $partitionValue);
     }
 
 	/**

--- a/src/CosmosDbDatabase.php
+++ b/src/CosmosDbDatabase.php
@@ -47,7 +47,7 @@ class CosmosDbDatabase
      * @access public
      * @param string $col_name Collection name
      */
-    public function selectCollection($col_name)
+    public function selectCollection($col_name, $partitionKey = null)
     {
         $rid_col = false;
         $object = json_decode($this->document_db->listCollections($this->rid_db));
@@ -58,7 +58,14 @@ class CosmosDbDatabase
             }
         }
         if (!$rid_col) {
-            $object = json_decode($this->document_db->createCollection($this->rid_db, '{"id":"' . $col_name . '"}'));
+            $col_body["id"] = $col_name;
+            if ($partitionKey) {
+                $col_body["partitionKey"] = [
+                    "paths" => [$partitionKey],
+                    "kind" => "Hash"
+                ];
+            }
+            $object = json_decode($this->document_db->createCollection($this->rid_db, json_encode($col_body)));
             $rid_col = $object->_rid;
         }
         if ($rid_col) {

--- a/src/CosmosDbDatabase.php
+++ b/src/CosmosDbDatabase.php
@@ -3,17 +3,17 @@
 namespace Jupitern\CosmosDb;
 
 /*
- * Copyright (C) 2014 - 2017 Takeshi SAKURAI <sakurai@pnop.co.jp>
- *      http://www.pnop.co.jp/
+ * Based on the AzureDocumentDB-PHP library written by Takeshi Sakurai.
+ * With updates and added features contributed by @jupitern and @purplekrayons
  *
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -21,13 +21,8 @@ namespace Jupitern\CosmosDb;
 
 /**
  * Microsoft Azure Document DB Library for PHP
- *
- * Wrapper class of Document DB REST API
- *
  * @link http://msdn.microsoft.com/en-us/library/azure/dn781481.aspx
- * @version 2.8
- * @author Takeshi SAKURAI <sakurai@pnop.co.jp>
- * @since PHP 5.3
+ * @link https://github.com/jupitern/cosmosdb
  */
 
 class CosmosDbDatabase

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -24,6 +24,7 @@ class QueryBuilder
     /** @var \Jupitern\CosmosDb\CosmosDbDatabase $db */
     private $collection = "";
     private $partitionKey = null;
+    private $partitionValue = null;
     private $fields = "";
     private $from = "c";
     private $join = "";


### PR DESCRIPTION
Implement a new method `->setPartitionValue()` to allow users to pass a known partition key when querying. This is to avoid having to use cross-partition queries, which can be a more costly method of querying. Passing the partition value will allow users to write more efficient Cosmos queries. See issue #15 for more details.

Useage example:

```php
$params["@formId"] = $formId;

$res = \Jupitern\CosmosDb\QueryBuilder::instance()
    ->setCollection($collection)
    ->setPartitionValue('enroll')
    ->select("*")
    ->where("c.id = @formId")
    ->params($params)
    ->find()
    ->toArray();
```