### PR TITLE
support partitioned queries

### DIFF
--- a/src/CosmosDbCollection.php
+++ b/src/CosmosDbCollection.php
@@ -3,17 +3,16 @@
 namespace Jupitern\CosmosDb;
 
 /*
- * Copyright (C) 2014 - 2017 Takeshi SAKURAI <sakurai@pnop.co.jp>
- *      http://www.pnop.co.jp/
+ * Based on the AzureDocumentDB-PHP library written by Takeshi Sakurai.
  *
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -21,13 +20,8 @@ namespace Jupitern\CosmosDb;
 
 /**
  * Microsoft Azure Document DB Library for PHP
- *
- * Wrapper class of Document DB REST API
- *
  * @link http://msdn.microsoft.com/en-us/library/azure/dn781481.aspx
- * @version 2.8
- * @author Takeshi SAKURAI <sakurai@pnop.co.jp>
- * @since PHP 5.3
+ * @link https://github.com/jupitern/cosmosdb
  */
 
 class CosmosDbCollection
@@ -59,7 +53,7 @@ class CosmosDbCollection
      * @param boolean $isCrossPartition used for cross partition query
      * @return string JSON strings
      */
-    public function query($query, $params = [], $isCrossPartition = false)
+    public function query($query, $params = [], $isCrossPartition = false, $partitionValue = null)
     {
         $paramsJson = [];
         foreach ($params as $key => $val) {
@@ -70,7 +64,7 @@ class CosmosDbCollection
 
         $query = '{"query": "' . str_replace('"', '\\"', $query) . '", "parameters": [' . implode(',', $paramsJson) . ']}';
 
-        return $this->document_db->query($this->rid_db, $this->rid_col, $query, $isCrossPartition);
+        return $this->document_db->query($this->rid_db, $this->rid_col, $query, $isCrossPartition, $partitionValue);
     }
 
 	/**
@@ -162,6 +156,7 @@ class CosmosDbCollection
         return $this->document_db->getPermission($this->rid_db, $uid, $pid);
       }
     */
+    
     public function listStoredProcedures()
     {
         return $this->document_db->listStoredProcedures($this->rid_db, $this->rid_col);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -3,27 +3,33 @@
 namespace Jupitern\CosmosDb;
 
 /*
- * Copyright (C) 2017 Nuno Chaves <nunochaves@sapo.pt>
+ * Based on the AzureDocumentDB-PHP library written by Takeshi Sakurai.
  *
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
+/**
+ * Microsoft Azure Document DB Library for PHP
+ * @link http://msdn.microsoft.com/en-us/library/azure/dn781481.aspx
+ * @link https://github.com/jupitern/cosmosdb
+ */
+
 class QueryBuilder
 {
-
-    /** @var \Jupitern\CosmosDb\CosmosDbDatabase $db */
     private $collection = "";
     private $partitionKey = null;
+    private $partitionValue = null;
+    private $queryString = "";
     private $fields = "";
     private $from = "c";
     private $join = "";
@@ -32,10 +38,8 @@ class QueryBuilder
     private $limit = null;
     private $triggers = [];
     private $params = [];
-
     private $response = null;
     private $multipleResults = false;
-
 
     /**
      * Initializes the Table.
@@ -47,7 +51,6 @@ class QueryBuilder
         return new static();
     }
 
-
     /**
      * @param CosmosDbCollection $collection
      * @return $this
@@ -57,7 +60,6 @@ class QueryBuilder
         $this->collection = $collection;
         return $this;
     }
-
 
     /**
      * @param string|array $fields
@@ -81,7 +83,6 @@ class QueryBuilder
         return $this;
     }
 
-
     /**
      * @param string $join
      * @return $this
@@ -91,7 +92,6 @@ class QueryBuilder
         $this->join .= " {$join} ";
         return $this;
     }
-
 
     /**
      * @param string $where
@@ -161,7 +161,6 @@ class QueryBuilder
         return $this->where("$field NOT IN('{$values}')");
     }
 
-
     /**
      * @param string $order
      * @return $this
@@ -171,7 +170,6 @@ class QueryBuilder
         $this->order = $order;
         return $this;
     }
-
 
     /**
      * @param int $limit
@@ -183,7 +181,6 @@ class QueryBuilder
         return $this;
     }
 
-
     /**
      * @param array $params
      * @return $this
@@ -193,7 +190,6 @@ class QueryBuilder
         $this->params = (array)$params;
         return $this;
     }
-
 
     /**
      * @param boolean $isCrossPartition
@@ -216,7 +212,6 @@ class QueryBuilder
         return $this;
     }
 
-
     /**
      * @param boolean $isCrossPartition
      * @return $this
@@ -226,13 +221,15 @@ class QueryBuilder
         $this->response = null;
         $this->multipleResults = false;
 
+        $partitionValue = $this->partitionValue != null ? $this->partitionValue : null;
+
         $fields = !empty($this->fields) ? $this->fields : '*';
         $where = $this->where != "" ? "where {$this->where}" : "";
         $order = $this->order != "" ? "order by {$this->order}" : "";
 
         $query = "SELECT top 1 {$fields} FROM {$this->from} {$this->join} {$where} {$order}";
 
-        $this->response = $this->collection->query($query, $this->params, $isCrossPartition);
+        $this->response = $this->collection->query($query, $this->params, $isCrossPartition, $partitionValue);
 
         return $this;
     }
@@ -252,7 +249,6 @@ class QueryBuilder
         return $this;
     }
 
-
     /**
      * @param $fieldName
      * @return $this
@@ -270,54 +266,105 @@ class QueryBuilder
     public function getPartitionKey()
 	{
 		return $this->partitionKey;
+    }
+    
+    /**
+     * @param $fieldName
+     * @return $this
+     */
+    public function setPartitionValue($fieldName)
+    {
+        $this->partitionValue = $fieldName;
+
+        return $this;
+    }
+
+    /**
+     * @return null
+     */
+    public function getPartitionValue()
+	{
+		return $this->partitionValue;
 	}
 
     /**
-     * @param string partition key
-     * @param object document
-     * @param bool if true, return property structure as string
-     * @return string partition value
+     * @param $fieldName
+     * @return $this
      */
-    public function getPartitionValue(object $document, bool $toString = false)
+    public function setQueryString(string $string)
+    {
+        $this->queryString .= $string;
+        return $this;
+    }
+
+    /**
+     * @return null
+     */
+    public function getQueryString()
+	{
+		return $this->queryString;
+	}
+
+    /**
+     * @param boolean $isCrossPartition
+     * @return $this
+     */
+    public function isNested(string $partitionKey)
     {
         # strip any slashes from the beginning
         # and end of the partition key
-        $partitionKey = trim($this->partitionKey, '/');
+        $partitionKey = trim($partitionKey, '/');
 
         # if the partition key contains slashes, the user
         # is referencing a nested value, so we should search for it
         if (strpos($partitionKey, '/') !== false) {
+            return true;
+        }
 
-            # explode the key into its parts
-            $properties = explode("/", $partitionKey);
+        return false;
+    }
 
-            # return the property structure as a
-            # string for use in cosmos queries
+    /**
+     * Find and set the partition value
+     * 
+     * @param object document
+     * @param bool if true, return property structure formatted for use in Azure query string
+     * @return string partition value
+     */
+    public function findPartitionValue(object $document, bool $toString = false)
+    {
+        # if the partition key contains slashes, the user
+        # is referencing a nested value, so we should find it
+        if ($this->isNested($this->partitionKey)) {
+
+            # explode the key into its properties
+            $properties = explode("/", $this->partitionKey);
+
+            # return the property structure
+            # formatted as a cosmos query string
             if ($toString) {
-                # build the property string
-                $docString = "";
+
                 foreach( $properties as $p ) {
-                    $docString .= ".{$p}";
+                    $this->setQueryString($p);
                 }
 
-                # return the property string
-                return $docString;
+                return $this->queryString;
             }
-            # otherwise, fetch the property key value
+            # otherwise, iterate through the document
+            # and find the value of the property key
             else {
 
-                # iterate through the document to find the nested value
                 foreach( $properties as $p ) {
                     $document = (object)$document->{$p};
                 }
 
-                # return the partition value
                 return $document->scalar;
             }
-
-        } else {
-            # return as if key were in root of the document
-            return $document->{$partitionKey};
+        }
+        # otherwise, assume the key is in the root of the
+        # document and return the value of the property key
+        else {
+            return $document->{$this->partitionKey};
         }
     }
 
@@ -331,7 +378,7 @@ class QueryBuilder
         $document = (object)$document;
 
         $rid = is_object($document) && isset($document->_rid) ? $document->_rid : null;
-        $partitionValue = $this->partitionKey != null ? $this->getPartitionValue($document) : null;
+        $partitionValue = $this->partitionKey != null ? $this->findPartitionValue($document) : null;
         $document = json_encode($document);
 
         $result = $rid ?
@@ -346,7 +393,7 @@ class QueryBuilder
         return $resultObj->_rid ?? null;
     }
 
-    /* DELETE */
+    /* delete */
 
     /**
      * @param boolean $isCrossPartition
@@ -357,12 +404,12 @@ class QueryBuilder
         $this->response = null;
 
         $select = $this->fields != "" ?
-            $this->fields : "c._rid" . ($this->partitionKey != null ? ", c.{$this->getPartitionValue($document, true)}" : "");
+            $this->fields : "c._rid" . ($this->partitionKey != null ? ", c.{$this->findPartitionValue($document, true)}" : "");
 
         $document = $this->select($select)->find($isCrossPartition)->toObject();
 
         if ($document) {
-            $partitionValue = $this->partitionKey != null ? $this->getPartitionValue($document) : null;
+            $partitionValue = $this->partitionKey != null ? $this->findPartitionValue($document) : null;
             $this->response = $this->collection->deleteDocument($document->_rid, $partitionValue, $this->triggersAsHeaders("delete"));
 
             return true;
@@ -370,7 +417,6 @@ class QueryBuilder
 
         return false;
     }
-
 
     /**
      * @param boolean $isCrossPartition
@@ -381,18 +427,17 @@ class QueryBuilder
         $this->response = null;
 
         $select = $this->fields != "" ?
-            $this->fields : "c._rid" . ($this->partitionKey != null ? ", c.{$this->getPartitionValue($document, true)}" : "");
+            $this->fields : "c._rid" . ($this->partitionKey != null ? ", c.{$this->findPartitionValue($document, true)}" : "");
 
         $response = [];
         foreach ((array)$this->select($select)->findAll($isCrossPartition)->toObject() as $document) {
-            $partitionValue = $this->partitionKey != null ? $this->getPartitionValue($document) : null;
+            $partitionValue = $this->partitionKey != null ? $this->findPartitionValue($document) : null;
             $response[] = $this->collection->deleteDocument($document->_rid, $partitionValue, $this->triggersAsHeaders("delete"));
         }
 
         $this->response = $response;
         return true;
     }
-
 
     /* triggers */
 
@@ -419,7 +464,6 @@ class QueryBuilder
         $this->triggers[$operation][$type][] = $id;
         return $this;
     }
-
 
     /**
      * @param string $operation
@@ -448,7 +492,6 @@ class QueryBuilder
 
         return $headers;
     }
-
 
     /* helpers */
 
@@ -502,5 +545,5 @@ class QueryBuilder
         $obj = $this->toObject();
         return isset($obj->{$fieldName}) ? $obj->{$fieldName} : $default;
     }
-
+    
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -200,6 +200,8 @@ class QueryBuilder
         $this->response = null;
         $this->multipleResults = true;
 
+        $partitionValue = $this->partitionValue != null ? $this->partitionValue : null;
+
         $limit = $this->limit != null ? "top " . (int)$this->limit : "";
         $fields = !empty($this->fields) ? $this->fields : '*';
         $where = $this->where != "" ? "where {$this->where}" : "";
@@ -207,7 +209,7 @@ class QueryBuilder
 
         $query = "SELECT {$limit} {$fields} FROM {$this->from} {$this->join} {$where} {$order}";
 
-        $this->response = $this->collection->query($query, $this->params, $isCrossPartition);
+        $this->response = $this->collection->query($query, $this->params, $isCrossPartition, $partitionValue);
 
         return $this;
     }


### PR DESCRIPTION
Implement a new method `->setPartitionValue()` to allow users to pass a known partition key when querying. This is to avoid having to use cross-partition queries, which can be a more costly method of querying. Passing the partition value will allow users to write more efficient Cosmos queries. See issue #15 for more details.

Useage example:

```php
$params["@formId"] = $formId;

$res = \Jupitern\CosmosDb\QueryBuilder::instance()
    ->setCollection($collection)
    ->setPartitionValue('enroll')
    ->select("*")
    ->where("c.id = @formId")
    ->params($params)
    ->find()
    ->toArray();
```

Also includes some general comment and readme updates, as well a minor read-ability and optimization changes.