### PR TITLE
PATCH API functionality implementation

### DIFF
--- a/src/CosmosDbCollection.php
+++ b/src/CosmosDbCollection.php
@@ -35,9 +35,9 @@ class CosmosDbCollection
     {
         $paramsJson = [];
         foreach ($params as $key => $val) {
-            $val = is_int($val) || is_float($val) ? $val : '"'. str_replace('"', '\\"', $val) .'"';
+            $val = is_int($val) || is_float($val) ? $val : '"' . str_replace('"', '\\"', $val) . '"';
 
-            $paramsJson[] = '{"name": "' . str_replace('"', '\\"', $key) . '", "value": '.$val.'}';
+            $paramsJson[] = '{"name": "' . str_replace('"', '\\"', $key) . '", "value": ' . $val . '}';
         }
 
         $query = '{"query": "' . str_replace('"', '\\"', $query) . '", "parameters": [' . implode(',', $paramsJson) . ']}';
@@ -45,25 +45,25 @@ class CosmosDbCollection
         return $this->document_db->query($this->rid_db, $this->rid_col, $query, $isCrossPartition, $partitionValue);
     }
 
-	/**
-	 * getPkRanges
-	 *
-	 * @return mixed
-	 */
-	public function getPkRanges()
-	{
-		return $this->document_db->getPkRanges($this->rid_db, $this->rid_col);
-	}
+    /**
+     * getPkRanges
+     *
+     * @return mixed
+     */
+    public function getPkRanges()
+    {
+        return $this->document_db->getPkRanges($this->rid_db, $this->rid_col);
+    }
 
-	/**
-	 * getPkFullRange
-	 *
-	 * @return mixed
-	 */
-	public function getPkFullRange()
-	{
-		return $this->document_db->getPkFullRange($this->rid_db, $this->rid_col);
-	}
+    /**
+     * getPkFullRange
+     *
+     * @return mixed
+     */
+    public function getPkFullRange()
+    {
+        return $this->document_db->getPkFullRange($this->rid_db, $this->rid_col);
+    }
 
     /**
      * createDocument
@@ -92,6 +92,21 @@ class CosmosDbCollection
     public function replaceDocument($rid, $json, $partitionKey = null, array $headers = [])
     {
         return $this->document_db->replaceDocument($this->rid_db, $this->rid_col, $rid, $json, $partitionKey, $headers);
+    }
+
+    /**
+     * patchDocument
+     *
+     * @access public
+     * @param  string $rid document ResourceID (_rid)
+     * @param string $json JSON formatted operations array
+     * @param string $partitionKey
+     * @param array $headers Optional headers to send along with the request
+     * @return string JSON strings
+     */
+    public function patchDocument($rid_doc, $operations, $partitionKey = null, array $headers = [])
+    {
+        return $this->document_db->patchDocument($this->rid_db, $this->rid_col, $rid_doc, $operations, $partitionKey, $headers);
     }
 
     /**
@@ -134,7 +149,7 @@ class CosmosDbCollection
         return $this->document_db->getPermission($this->rid_db, $uid, $pid);
       }
     */
-    
+
     public function listStoredProcedures()
     {
         return $this->document_db->listStoredProcedures($this->rid_db, $this->rid_col);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -375,7 +375,7 @@ class QueryBuilder
      * @return array Fully formed MOVE patch operation element
      */
 
-    public function patchOpMove(string $fromPath, string $toPath): array
+    public function getPatchOpMove(string $fromPath, string $toPath): array
     {
 
         $op = [

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -89,9 +89,9 @@ class QueryBuilder
      * @return QueryBuilder
      */
     public function whereStartsWith(string $field, mixed $value): static
-	{
-		return $this->where("STARTSWITH($field, '{$value}')");
-	}
+    {
+        return $this->where("STARTSWITH($field, '{$value}')");
+    }
 
     /**
      * @param string $field
@@ -100,8 +100,8 @@ class QueryBuilder
      */
     public function whereEndsWith(string $field, mixed $value): static
     {
-		return $this->where("ENDSWITH($field, '{$value}')");
-	}
+        return $this->where("ENDSWITH($field, '{$value}')");
+    }
 
     /**
      * @param string $field
@@ -110,8 +110,8 @@ class QueryBuilder
      */
     public function whereContains(string $field, mixed $value): static
     {
-		return $this->where("CONTAINS($field, '{$value}'");
-	}
+        return $this->where("CONTAINS($field, '{$value}'");
+    }
 
     /**
      * @param string $field
@@ -119,11 +119,11 @@ class QueryBuilder
      * @return $this|QueryBuilder
      */
     public function whereIn(string $field, array $values): QueryBuilder|static
-	{
-	    if (empty($values)) return $this;
+    {
+        if (empty($values)) return $this;
 
-		return $this->where("$field IN('".implode("', '", $values)."')");
-	}
+        return $this->where("$field IN('" . implode("', '", $values) . "')");
+    }
 
     /**
      * @param string $field
@@ -134,7 +134,7 @@ class QueryBuilder
     {
         if (empty($values)) return $this;
 
-        return $this->where("$field NOT IN('".implode("', '", $values)."')");
+        return $this->where("$field NOT IN('" . implode("', '", $values) . "')");
     }
 
     /**
@@ -171,6 +171,7 @@ class QueryBuilder
      * @param boolean $isCrossPartition
      * @return $this
      */
+
     public function findAll(bool $isCrossPartition = false): static
     {
         $this->response = null;
@@ -229,10 +230,10 @@ class QueryBuilder
      * @return null
      */
     public function getPartitionKey()
-	{
-		return $this->partitionKey;
+    {
+        return $this->partitionKey;
     }
-    
+
     /**
      * @param $fieldName
      * @return $this
@@ -248,9 +249,9 @@ class QueryBuilder
      * @return null
      */
     public function getPartitionValue()
-	{
-		return $this->partitionValue;
-	}
+    {
+        return $this->partitionValue;
+    }
 
     /**
      * @param string $string
@@ -267,8 +268,8 @@ class QueryBuilder
      */
     public function getQueryString(): ?string
     {
-		return $this->queryString;
-	}
+        return $this->queryString;
+    }
 
     /**
      * @param string $partitionKey
@@ -283,6 +284,106 @@ class QueryBuilder
         # if the partition key contains slashes, the user
         # is referencing a nested value, so we should search for it
         return str_contains($partitionKey, '/');
+    }
+
+    /**
+     * @param string $path Instances of / in property names within $path must be escaped as /~1
+     * @param mixed $value
+     * @return array Fully formed ADD patch operation element
+     */
+
+    public function getPatchOpAdd(string $path, mixed $value): array
+    {
+
+        $op = [
+            'op' => 'add',
+            'path' => str_replace('~', '~0', $path),
+            'value' => $value
+        ];
+        return $op;
+    }
+
+    /**
+     * @param string $path Instances of / in property names within $path must be escaped as /~1
+     * @param mixed $value
+     * @return array Fully formed SET patch operation element
+     */
+
+    public function getPatchOpSet(string $path, mixed $value): array
+    {
+
+        $op = [
+            'op' => 'set',
+            'path' => str_replace('~', '~0', $path),
+            'value' => $value
+        ];
+        return $op;
+    }
+
+    /**
+     * @param string $path Instances of / in property names within $path must be escaped as /~1
+     * @param mixed $value
+     * @return array Fully formed REPLACE patch operation element
+     */
+
+    public function getPatchOpReplace(string $path, mixed $value): array
+    {
+
+        $op = [
+            'op' => 'replace',
+            'path' => str_replace('~', '~0', $path),
+            'value' => $value
+        ];
+        return $op;
+    }
+
+   /**
+     * @param string $path Instances of / in property names within $path must be escaped as /~1
+     * @return array Fully formed REMOVE patch operation element
+     */
+
+    public function getPatchOpRemove(string $path): array
+    {
+
+        $op = [
+            'op' => 'remove',
+            'path' => str_replace('~', '~0', $path),
+        ];
+        return $op;
+    }
+
+    /**
+     * @param string $path Instances of / in property names within $path must be escaped as /~1
+     * @param int $value
+     * @return array Fully formed INCR patch operation element
+     */
+
+    public function getPatchOpIncrement(string $path, int $value): array
+    {
+
+        $op = [
+            'op' => 'replace',
+            'path' => str_replace('~', '~0', $path),
+            'value' => $value
+        ];
+        return $op;
+    }
+
+    /**
+     * @param string $fromPath Source property - Instances of / in property names within $path must be escaped as /~1
+     * @param string $toPath Destination property - Instances of / in property names within $path must be escaped as /~1
+     * @return array Fully formed MOVE patch operation element
+     */
+
+    public function patchOpMove(string $fromPath, string $toPath): array
+    {
+
+        $op = [
+            'op' => 'replace',
+            'from' => str_replace('~', '~0', $fromPath),
+            'path' => str_replace('~', '~0', $toPath),
+        ];
+        return $op;
     }
 
     /**
@@ -305,7 +406,7 @@ class QueryBuilder
             # formatted as a cosmos query string
             if ($toString) {
 
-                foreach( $properties as $p ) {
+                foreach ($properties as $p) {
                     $this->setQueryString($p);
                 }
 
@@ -315,7 +416,7 @@ class QueryBuilder
             # and find the value of the property key
             else {
 
-                foreach( $properties as $p ) {
+                foreach ($properties as $p) {
                     $document = (object)$document->{$p};
                 }
 
@@ -354,13 +455,49 @@ class QueryBuilder
         return $resultObj->_rid ?? null;
     }
 
+    /**
+     * @param $rid_doc
+     * @param $patchOps Array Array of operations, max 10 per request	
+     * @return string|null
+     * @throws \Exception
+     */
+    public function patch(string $rid_doc, array $patchOps)
+    {
+        if (count($patchOps) > 10) {
+            //Throw an equivalent HTTP error rather than waste a request to have the API return the same
+            throw new \Exception("400 : PATCH supports maximum of 10 operations per request");
+        };
+
+        $partitionValue = $this->partitionKey != null ? $this->partitionValue : null;
+        //Conditional patch is possible - check if QueryBuilder was set up with a condition and append
+        $condition = ($this->where) ? 'from ' . $this->from . ' where ' . $this->where : '';
+
+        $updates = [];
+        if ($condition) {
+            $updates['condition'] = $condition;
+        };
+        $updates['operations'] = $patchOps;
+        $json = json_encode($updates);
+
+        $result = $this->collection->patchDocument($rid_doc, $json, $partitionValue, $this->triggersAsHeaders("patch"));
+        $resultObj = json_decode($result);
+
+        if (isset($resultObj->code) && isset($resultObj->message)) {
+            throw new \Exception("$resultObj->code : $resultObj->message");
+        }
+
+        return $resultObj->_rid ?? null;
+    }
+
+
+
     /* delete */
 
     /**
      * @param boolean $isCrossPartition
      * @return boolean
      */
-    public function delete(bool $isCrossPartition = false) :bool
+    public function delete(bool $isCrossPartition = false): bool
     {
         $this->response = null;
 
@@ -382,7 +519,7 @@ class QueryBuilder
      * @param boolean $isCrossPartition
      * @return boolean
      */
-    public function deleteAll(bool $isCrossPartition = false) :bool
+    public function deleteAll(bool $isCrossPartition = false): bool
     {
         $this->response = null;
 
@@ -410,7 +547,7 @@ class QueryBuilder
     public function addTrigger(string $operation, string $type, string $id): self
     {
         $operation = \strtolower($operation);
-        if (!\in_array($operation, ["all", "create", "delete", "replace"]))
+        if (!\in_array($operation, ["all", "create", "delete", "replace", "patch"]))
             throw new \Exception("Trigger: Invalid operation \"{$operation}\"");
 
         $type = \strtolower($type);
@@ -432,7 +569,7 @@ class QueryBuilder
     {
         $headers = [];
 
-        // Add headers for the current operation type at $operation (create|delete!replace)
+        // Add headers for the current operation type at $operation (create|delete!replace|patch)
         if (isset($this->triggers[$operation])) {
             foreach ($this->triggers[$operation] as $name => $ids) {
                 $ids = \is_array($ids) ? $ids : [$ids];
@@ -520,7 +657,7 @@ class QueryBuilder
         $results = (array)$this->toObject($arrayKey);
 
         if ($this->multipleResults && is_array($results)) {
-            array_walk($results, function(&$value) {
+            array_walk($results, function (&$value) {
                 $value = (array)$value;
             });
         }
@@ -533,9 +670,8 @@ class QueryBuilder
      * @param null $default
      * @return mixed
      */
-    public function getValue($fieldName, $default = null)
+    public function getValue($fieldName, $default = null) 
     {
         return ($this->toObject())->{$fieldName} ?? $default;
     }
-    
 }


### PR DESCRIPTION
**Implementing PATCH operation from the additional [Partial document update in Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update) API extension overlaying the 2018-12-31 REST API version 3.**

- Implementing a set of new `getPatchOp[VERB]` functions to `QueryBuilder` to handle all available PATCH operations;
[Similarities and differences between PATCH operations](https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update#similarities-and-differences)

  - ADD
  - SET
  - REPLACE
  - REMOVE
  - INCREMENT
  - MOVE

  Ensures conforming patch operation elements are generated to be passed into the new patch method `$operations` array rather than relying on a top level calling function having to populate the array _manually_.
  
  _NB: We decided not to implement a class level `$patch` array property similar to `$queryString` etc because the content is single use per call to the `patch` method, so if a class property is populated by the `getPatchOp[VERB]` functions, it would always be in an unknown state and would have to be continually cleared after each success patch operation to avoid duplicating requests. Therefore the `getPatchOp[VERB]` functions simply return the fully formed operation element as a PHP array. The functions are intended to be used to build an array of arrays of `ops` in the local scope to be passed to the `patch` method on a per-request basis, where the elements are then configured into the correct wrapper and encoded as JSON within the patch method itself._

- Implementing PATCH verb via a new `patch` method in the `QueryBuilder` methods, attempting to follow the existing methods and conventions, adding/expanding dependent functionality up-chain in the `CosmosDbCollection` and `CosmosDB` class functions.

- Best efforts to align whitespace scheme with original project (apologies for any differences due to differing indent configuration in my IDE, I tried to align with limited success)


_We have used this package very successfully for some time now, but required access to the PATCH method which appears to sit outside the officially versioned REST API. We have attempted to follow the established approach when expanding the implementation, in the hope that it might be accepted/revised and adopted so that we may continue to use this excellent library via the mainstream composer package rather than splitting off ourselves, but also expose the PATCH functionality to other subscribers to the project._