### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/CosmosDb.php
+++ b/src/CosmosDb.php
@@ -528,7 +528,7 @@ class CosmosDb
      * @return string JSON response
      * @throws GuzzleException
      */
-    public function createDocument(string $rid_id, string $rid_col, string $json, string $partitionKey = null, array $headers = []): string
+    public function createDocument(string $rid_id, string $rid_col, string $json, ?string $partitionKey = null, array $headers = []): string
     {
         $authHeaders = $this->getAuthHeaders('POST', 'docs', $rid_col);
         $headers = \array_merge($headers, $authHeaders);
@@ -554,7 +554,7 @@ class CosmosDb
      * @return string JSON response
      * @throws GuzzleException
      */
-    public function replaceDocument(string $rid_id, string $rid_col, string $rid_doc, string $json, string $partitionKey = null, array $headers = []): string
+    public function replaceDocument(string $rid_id, string $rid_col, string $rid_doc, string $json, ?string $partitionKey = null, array $headers = []): string
     {
         $authHeaders = $this->getAuthHeaders('PUT', 'docs', $rid_doc);
         $headers = \array_merge($headers, $authHeaders);
@@ -580,7 +580,7 @@ class CosmosDb
      * @return string JSON response
      * @throws GuzzleException
      */
-    public function patchDocument(string $rid_id, string $rid_col, string $rid_doc, string $json, string $partitionKey = null, array $headers = []): string
+    public function patchDocument(string $rid_id, string $rid_col, string $rid_doc, string $json, ?string $partitionKey = null, array $headers = []): string
     {
         $authHeaders = $this->getAuthHeaders('PATCH', 'docs', $rid_doc);
         $headers = \array_merge($headers, $authHeaders);
@@ -606,7 +606,7 @@ class CosmosDb
      * @return string JSON response
      * @throws GuzzleException
      */
-    public function deleteDocument(string $rid_id, string $rid_col, string $rid_doc, string $partitionKey = null, array $headers = []): string
+    public function deleteDocument(string $rid_id, string $rid_col, string $rid_doc, ?string $partitionKey = null, array $headers = []): string
     {
         $authHeaders = $this->getAuthHeaders('DELETE', 'docs', $rid_doc);
         $headers = \array_merge($headers, $authHeaders);

--- a/src/CosmosDbDatabase.php
+++ b/src/CosmosDbDatabase.php
@@ -42,7 +42,7 @@ class CosmosDbDatabase
      * @return CosmosDbCollection|null
      * @throws GuzzleException
      */
-    public function createCollection(string $col_name, string $partitionKey = null): CosmosDbCollection|null
+    public function createCollection(string $col_name, ?string $partitionKey = null): CosmosDbCollection|null
     {
         $col_body = ["id" => $col_name];
         if ($partitionKey) {


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead